### PR TITLE
Comments xmlMode line to make false

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,7 +95,7 @@ gulp.task( 'inline:css', function( done ) {
 			juice( {
 				applyHeightAttributes: false,
 				applyWidthAttributes: false,
-				xmlMode: true,
+				// xmlMode: true,
 				// preserveMediaQueries: false,
 				webResources: {
 					relativeTo: path.resolve( __dirname, 'temp/' ),


### PR DESCRIPTION
### What did you change? 
Comments line related to `xmlMode` to make it false


### Why ?
Currently when running the command `npm run gulp dist` we have the following result:

<img width="681" alt="Captura de Tela 2022-02-09 às 20 52 32" src="https://user-images.githubusercontent.com/8038365/153315973-c847c5b5-82d3-42b3-9676-2951c2db6aa4.png">

When removing `xmlMode` we get the expected result, correctly rendering the variables:

<img width="676" alt="Captura de Tela 2022-02-09 às 20 54 10" src="https://user-images.githubusercontent.com/8038365/153316054-485d678e-387e-493c-8826-9214edb35f00.png">


### How to test it? 
Run the `npm run build` command and see if the emails were generated correctly
