### PR TITLE
Fix eval helper to match VTEX's implementation

### DIFF
--- a/source/helpers/helpers.js
+++ b/source/helpers/helpers.js
@@ -137,7 +137,7 @@ helpers.math = function( lvalue, operator, rvalue ) {
 
 helpers.eval = function( expr, options ) {
 	'use strict';
-	var reg = new RegExp( '\\${( \\S+ )}', 'g' );
+	var reg = new RegExp( '\\${(\\S+)}', 'g' );
 	var compiled = expr.replace( reg, function( match, pull ) {
 		return options.hash[ pull ];
 	} );


### PR DESCRIPTION
There are extra spaces (probably due to code autoformatting) in the regex inside the eval helper that make it behave differently from VTEX's actual eval helper. This PR fixes this.

## Tests
Here's the result of the expression `{{eval "'${string}'.split(' ')[0]" string=_accountInfo.CompanyName}}` inside an 'Order Confirmation' template on a VTEX production environment:
<img width="1188" alt="Screen Shot 2022-05-03 at 20 08 08" src="https://user-images.githubusercontent.com/1228352/166587445-c48ba98b-f2cf-419a-9cd0-554f1f7bc5dc.png">

Here's the result in the current version of `vtex-emails` (before this fix):
<img width="1188" alt="Screen Shot 2022-05-03 at 20 06 12" src="https://user-images.githubusercontent.com/1228352/166587147-161056a5-7be2-44ad-ab06-3df6518d0ed3.png">

Here's the result after the fix:
<img width="1188" alt="Screen Shot 2022-05-03 at 20 07 30" src="https://user-images.githubusercontent.com/1228352/166587300-dd8c5571-4488-442e-b4c3-ec32143afff5.png">